### PR TITLE
Gravity force remap

### DIFF
--- a/Dev Log.txt
+++ b/Dev Log.txt
@@ -82,3 +82,6 @@ Monday 27/01/2025
 06/01/2025
 - Zero development in previous days because of catching up with other modules taken.
 - Had a power blackout from 5 PM to 5 AM on different parts of the city due to a storm.
+
+08/02/2025
+-First re mapping of gravity force pull magnitude for better control of magnitude based on distance to the planet 

--- a/Dev Log.txt
+++ b/Dev Log.txt
@@ -78,3 +78,7 @@ Monday 27/01/2025
 	-Map gravity field pull to half its strength on the outside since using the square of the distance makes it
          unnoticeable when ball is on the outer zone of the edge and increasing pull magnitude will make it hard to shoot
 	planet surface.
+
+06/01/2025
+- Zero development in previous days because of catching up with other modules taken.
+- Had a power blackout from 5 PM to 5 AM on different parts of the city due to a storm.

--- a/Grolfvity/Assets/Prototypes/Gravity_field.unity
+++ b/Grolfvity/Assets/Prototypes/Gravity_field.unity
@@ -614,6 +614,14 @@ PrefabInstance:
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 7892716235291961589, guid: 1905fe6af13e8b644a0b696120f2dfe1, type: 3}
+      propertyPath: distCap
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8295284000571698316, guid: 1905fe6af13e8b644a0b696120f2dfe1, type: 3}
+      propertyPath: m_Radius
+      value: 4
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Grolfvity/Assets/Scripts/BallBehaviour.cs
+++ b/Grolfvity/Assets/Scripts/BallBehaviour.cs
@@ -87,7 +87,7 @@ public class BallBehaviour : MonoBehaviour
         {
             bounceCount++;
             SoundController.Instance.PlaySFX(SoundController.Instance.ballBounce, 0.5f);
-            Debug.Log(bounceCount);
+            //Debug.Log(bounceCount);
         }
     }
 

--- a/Grolfvity/Assets/Scripts/Controllers/GameController.cs
+++ b/Grolfvity/Assets/Scripts/Controllers/GameController.cs
@@ -46,7 +46,7 @@ public class GameController : MonoBehaviour
 
     public void IncrementHits()
     {
-        Debug.Log("Hits incremented");
+        //Debug.Log("Hits incremented");
         levelStrokes++;
         totalStrokes++;
     }

--- a/Grolfvity/Assets/Scripts/PlanetForces.cs
+++ b/Grolfvity/Assets/Scripts/PlanetForces.cs
@@ -3,12 +3,26 @@ using System.Collections.Generic;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UIElements;
+using Unity.Mathematics;
+using UnityEditor.Build.Content;
 
 public class PlanetForces : MonoBehaviour
 {
     //Variables for controlling gravity field
     [Header("Replaces G*m1*m2")]
     [SerializeField] float pullMagnitude;
+    [Header("Factor cap magnitude reduction based on distance. " +
+        "Example: 2 means pull is half as strong in the edge of the field as compared to the center." +
+        "Default = 0 means normal magnitude reduction based square of distance")]
+    [SerializeField] float distCap;
+
+    //Variables used for remapping force magnitude
+    private float planetRadius;
+    private float fieldRadius;
+    private float oldRangeMin;
+    private float oldRangeMax;
+    private float newRangeMin;
+    private float newRangeMax;
 
     //Ball reference for when coming field
     GameObject ball;
@@ -16,7 +30,25 @@ public class PlanetForces : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        
+        //Getting planet and field radii for force calculation later
+        CircleCollider2D[] allColliders = transform.parent.GetComponentsInChildren<CircleCollider2D>();
+        for(int i = 0; i < allColliders.Length; i++)
+        {
+            if(allColliders[i].gameObject.name == "Hitbox")
+            {
+                planetRadius = allColliders[i].radius;
+            }
+            else
+            {
+                fieldRadius = allColliders[i].radius;
+            }
+        }
+
+        oldRangeMin = Mathf.Pow(planetRadius, 2);
+        oldRangeMax = Mathf.Pow(fieldRadius, 2);
+        newRangeMin = oldRangeMin;
+        newRangeMax = distCap * oldRangeMin;
+
     }
 
     // Update is called once per frame
@@ -58,12 +90,27 @@ public class PlanetForces : MonoBehaviour
     {
         //Distance between objects transforms
         Vector2 difference = this.transform.position - ballTransform.position;
-        float distanceModifier = difference.magnitude;
+        float distToBall = difference.magnitude;
 
         //float distanceModifier = Vector3.Distance(this.transform.position, ballTransform.position);
 
-        //F = G * (m1*m2) / r^2 
-        float forceMagnitude = pullMagnitude / (Mathf.Pow(distanceModifier, 2));
+        //F = G * (m1*m2) / r^2
+        float distFactor; // How much to scale down the pull foce based on distance
+        
+        //Remapping force scaling based on distance
+        if(distCap == 0)
+        {
+            distFactor =  Mathf.Pow(distToBall, 2);
+        }
+        else
+        {
+            float temporary = Mathf.InverseLerp(oldRangeMax, oldRangeMin, Mathf.Pow(distToBall, 2));
+            distFactor = Mathf.Lerp(newRangeMax, newRangeMin, temporary);
+        }
+
+        float forceMagnitude = pullMagnitude / distFactor;
+
+        Debug.Log("Pull magnitude = " + pullMagnitude + " / " + distFactor);
 
         Vector2 pullDirection = difference.normalized;
         //Vector2 pullDirection = Vector3.Normalize(this.transform.position - ballTransform.position);


### PR DESCRIPTION
Remap of gravity force magnitude
The remap is made so the pull magnitude at the edge of the field can be determined based on the pull magnitude at the surface of the planet. This is done by linear interpolation and gives more control in order to vary  the different radius of planets and their respective fields without making the force at the edge of bigger planet fields negligible.